### PR TITLE
WP-12530 cell and column values showing up as formula for excel imports

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -103,7 +103,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "bcrypt"
-version = "4.0.0"
+version = "4.0.1"
 description = "Modern password hashing for your software and your servers"
 category = "main"
 optional = false
@@ -215,7 +215,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "38.0.1"
+version = "38.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -291,7 +291,7 @@ xlrd = "2.0.1"
 type = "git"
 url = "ssh://git@github.com/symon-ai/file-processors.git"
 reference = "v1.0.0"
-resolved_reference = "64aa00b9efff39ae7b0cefea5483364a470c3177"
+resolved_reference = "172040d8fb9e8b5bc989f998c1dc31d0894e52a6"
 
 [[package]]
 name = "filelock"
@@ -354,7 +354,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.12.0"
+version = "5.0.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -365,9 +365,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -448,7 +448,7 @@ python-versions = ">=3.7,<3.11"
 
 [[package]]
 name = "numpy"
-version = "1.23.3"
+version = "1.23.4"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -829,7 +829,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -902,20 +902,20 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "zipp"
-version = "3.8.1"
+version = "3.9.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "jaraco.functools", "more-itertools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "2bd26cc9283c9459ee0f21cb4d5c88c575a52288c6629f165ca4436fa97e1fc7"
+content-hash = "2d0211a8229c6ca46430dd7ae3f8568fec28688d4aab7f4038d206ea9d1bc23d"
 
 [metadata.files]
 aiobotocore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ terminaltables = "3.1.0"
 boto3 = "1.24.35"
 smart-open = "^6.1.0"
 python-gnupg = {git = "ssh://git@github.com/symon-ai/python-gnupg.git", rev = "0.4.9.1"}
-file-processors = {git = "ssh://git@github.com/symon-ai/file-processors.git", rev = "v1.0.0"}
+file-processors = {git = "ssh://git@github.com/symon-ai/file-processors.git", tag = "v1.0.0"}
 
 [tool.poetry.dev-dependencies]
 tox = "3.25.1"


### PR DESCRIPTION
Tap-sftp didn't have the correct reference to file-processors that contained the fix. Changed to using tag instead of rev in pyproject.toml when importing file-processors. From poetry docs it looks like rev is for referencing a specific commit hash whereas tag is more appropriate for us.

https://varicent.atlassian.net/browse/WP-12530