### PR TITLE
WP-22076: FWF Import files that use \r instead of \n for new line characters are not being read on import connectors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -798,8 +798,8 @@ xlrd = "2.0.1"
 [package.source]
 type = "git"
 url = "ssh://git@github.com/symon-ai/file-processors.git"
-reference = "v1.4.0"
-resolved_reference = "e6fbb40a8c3357274a63eb708db84f1c20c5c0b7"
+reference = "WP-22076"
+resolved_reference = "46454ebbe3641eb25398979c43092fb66bcf16a5"
 
 [[package]]
 name = "filelock"
@@ -2516,4 +2516,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.1"
-content-hash = "c676bacf6c39964b3d3c3998eb2a822d01dd53e52d3d8db517dfe376392f4433"
+content-hash = "1318e418c5d50316e2d38e60034d0311229aadd7b9fe0074db6e140a2e64f14f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ terminaltables = "3.1.0"
 boto3 = "1.24.35"
 smart-open = "^6.1.0"
 python-gnupg = {git = "ssh://git@github.com/symon-ai/python-gnupg.git", tag = "0.4.9.1"}
-file-processors = {git = "ssh://git@github.com/symon-ai/file-processors.git", tag = "v1.4.0"}
+file-processors = {git = "ssh://git@github.com/symon-ai/file-processors.git", branch = "WP-22076"}
 
 [tool.poetry.dev-dependencies]
 tox = "3.25.1"

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -209,7 +209,7 @@ class SFTPConnection():
                                                                       'passphrase'),
                                                                   f'{tmp_dir_name}/{original_file_name}')
                 try:
-                    if file_type in ["csv", "text"]:
+                    if file_type in ["csv", "text", "fwf"]:
                         if not encoding:
                             enc = find_encoding.find_encoding_v2(decrypt_path)
                         return open(decrypt_path, 'r', encoding=enc, newline="", errors="replace")
@@ -220,7 +220,7 @@ class SFTPConnection():
                         f'tap_sftp.decryption_error: Decryption of file failed: {sftp_file_path}')
             else:
                 self.sftp.get(sftp_file_path, local_path)
-                if file_type in ["csv", "text"]:
+                if file_type in ["csv", "text", "fwf"]:
                     if not encoding:
                         enc = find_encoding.find_encoding_v2(local_path)
                     return open(local_path, 'r', encoding=enc, newline="", errors="replace")
@@ -245,7 +245,7 @@ class SFTPConnection():
                                                              f'{tmp_dir_name}/{original_file_name}',
                                                              max_records)
                     try:
-                        if file_type in ["csv", "text"]:
+                        if file_type in ["csv", "text", "fwf"]:
                             if not encoding:
                                 enc = find_encoding.find_encoding_v2(sample_file)
                             return open(sample_file, 'r', encoding=enc, newline="",errors="replace")
@@ -257,7 +257,7 @@ class SFTPConnection():
                 else:
                     sample_file = helper.sample_file(
                         sftp_file_object, sftp_file_name, tmp_dir_name, max_records)
-                    if file_type in ["csv", "text"]:
+                    if file_type in ["csv", "text", "fwf"]:
                         if not encoding:
                             enc = find_encoding.find_encoding_v2(sample_file)
                         return open(sample_file, 'r', encoding=enc, newline="", errors="replace")


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-22076

Adding string reader to be passed when FWF file detected

Tests:
Old fwf: passes
New FWF with end line character: Passes

Related:
https://github.com/symon-ai/file-processors/pull/74
